### PR TITLE
Remove fetching the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,17 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Fetch sources
+        uses: actions/checkout@v4
       - name: Run protolint
         uses: frequenz-io/gh-action-protolint@v0.x.x
 ```
 
 By default, the action will checkout submodules (non-recursively) and use the
-`secrets.github_token` to do both the fetching and to do GitHub API calls to
-comment in PRs for example. It looks for proto files in the `proto/` directory
-and uses a fixed protolint version (please look at the
-[`action.yml`](./action.yml) file for the current version).
+`secrets.github_token` to do GitHub API calls to comment in PRs for example. It
+looks for proto files in the `proto/` directory and uses a fixed protolint
+version (please look at the [`action.yml`](./action.yml) file for the current
+version).
 
 You can change those defaults using custom inputs. For example:
 
@@ -32,12 +34,12 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: Fetch sources
+        uses: actions/checkout@v4
       - name: Run protolint
         uses: frequenz-io/gh-action-protolint@v0.x.x
         with:
-          submodules: recursive
-          checkout_token: ${{ secrets.my_checkout_token }}
-          api_token: ${{ secrets.my_api_token }}
+          github_token: ${{ secrets.my_api_token }}
           protolint_flags: "-config_path=.github/protolint.yaml proto/"
           protolint_version: "v0.46.0"
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Run protolint
-        uses: frequenz-io/gh-action-protolint@v0.x.x
+        uses: frequenz-floss/gh-action-protolint@v0.x.x
 ```
 
 By default, the action will checkout submodules (non-recursively) and use the
@@ -37,7 +37,7 @@ jobs:
       - name: Fetch sources
         uses: actions/checkout@v4
       - name: Run protolint
-        uses: frequenz-io/gh-action-protolint@v0.x.x
+        uses: frequenz-floss/gh-action-protolint@v0.x.x
         with:
           github_token: ${{ secrets.my_api_token }}
           protolint_flags: "-config_path=.github/protolint.yaml proto/"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
 ```
 
 By default, the action will checkout submodules (non-recursively) and use the
-`secrets.github_token` to do GitHub API calls to comment in PRs for example. It
+`github.token` to do GitHub API calls to comment in PRs for example. It
 looks for proto files in the `proto/` directory and uses a fixed protolint
 version (please look at the [`action.yml`](./action.yml) file for the current
 version).

--- a/action.yaml
+++ b/action.yaml
@@ -18,9 +18,9 @@ inputs:
   github_token:
     description: >
       The token to use to make comments and annotations to pull requests.
-      Uses secrets.github_token by default.
+      Uses github.token by default.
     required: false
-    default: ${{ secrets.github_token }}
+    default: ${{ github.token }}
   protolint_flags:
     description: >
       The flags to pass to protolint. At least the path to the proto files

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Protolint"
-description: "Run protolint on the repository"
+description: "Run protolint with some custom options"
 author: "Frequenz Energy-as-a-Service GmbH"
 
 # Refer to the following link(s) for more information on inputs:
@@ -15,13 +15,7 @@ inputs:
       more information.
     required: false
     default: "true"
-  checkout_token:
-    description: >
-      The token to use for fetching the repository and submodules. Uses
-      secrets.github_token by default.
-    required: false
-    default: ${{ secrets.github_token }}
-  api_token:
+  github_token:
     description: >
       The token to use to make comments and annotations to pull requests.
       Uses secrets.github_token by default.
@@ -46,18 +40,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Fetch sources
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        token: ${{ inputs.checkout_token }}
-        submodules: ${{ inputs.submodules }}
-
     - name: Run protolint
       uses: yoheimuta/action-protolint@e62319541dc5107df5e3a5010acb8987004d3d25 # v1.3.0
       with:
         fail_on_error: true
         filter_mode: nofilter
-        github_token: ${{ inputs.api_token }}
+        github_token: ${{ inputs.github_token }}
         protolint_flags: ${{ inputs.protolint_flags }}
         protolint_version: ${{ inputs.protolint_version }}
         reporter: github-check


### PR DESCRIPTION
Doing the fetching ourselves means we need to either forward a lot of options to the `actions/checkout` action or make this action very inflexible.

The main point of this action is to provide some common configuration that all repositories will use by default.
